### PR TITLE
Implement TimeSlot initialisation

### DIFF
--- a/src/main/java/com/otacilio/challange/stylistscheduler/StylistSchedulerApplication.java
+++ b/src/main/java/com/otacilio/challange/stylistscheduler/StylistSchedulerApplication.java
@@ -27,47 +27,47 @@ public class StylistSchedulerApplication {
         SpringApplication.run(StylistSchedulerApplication.class, args);
     }
 
-    @Bean
-    public CommandLineRunner initDatabase(CustomerRepository customerRepository, StylistRepository
-            stylistRepository, TimeSlotRepository timeSlotRepository, AppointmentRepository appointmentRepository) {
-        return args -> {
-            Customer customer1 = customerRepository.save(new Customer("Customer1", "Customer1@gmail.com"));
-            Customer customer2 = customerRepository.save(new Customer("Customer2", "Customer2@gmail.com"));
-            log.info("CUSTOMER " + customer1);
-            log.info("CUSTOMER " + customer2);
-
-            Stylist stylist1 = stylistRepository.save(new Stylist("stylist1", "stylist1@gmail.com"));
-            Stylist stylist2 = stylistRepository.save(new Stylist("stylist2", "stylist2@gmail.com"));
-            log.info("STYLIST " + stylist1);
-            log.info("STYLIST " + stylist2);
-
-            // Should return just one available since they cover the same time frame
-            timeSlotRepository.save(new TimeSlot(stylist1,
-                    LocalDate.now(),
-                    LocalTime.of(6, 30),
-                    LocalTime.of(7, 0)));
-            timeSlotRepository.save(new TimeSlot(stylist2,
-                    LocalDate.now(),
-                    LocalTime.of(6, 30),
-                    LocalTime.of(7, 0)));
-
-            TimeSlot slot1 = timeSlotRepository.save(
-                    new TimeSlot(stylist1, LocalDate.now(), LocalTime.of(6, 0),
-                            LocalTime.of(6, 30)));
-            log.info("TIME SLOT " + slot1);
-            log.info("TIME SLOT " + timeSlotRepository.save(new TimeSlot(stylist2, LocalDate.now(), LocalTime.of(6, 0),
-                    LocalTime.of(6, 30))));
-
-            Appointment appointment1 = appointmentRepository.save(new Appointment(customer1, slot1));
-            log.info("APPOINTMENT " + appointment1);
-
-            slot1.setAppointment(appointment1);
-            log.info("UPDATE TIME SLOT " + timeSlotRepository.save(slot1));
-
-            List<TimeSlot> available = timeSlotRepository.findAllByDateBetweenAndAppointmentIsNull(LocalDate
-                    .now().minusDays(1), LocalDate.now().plusDays(2));
-            log.info("AVAILABLE " + available);
-        };
-    }
+//    @Bean
+//    public CommandLineRunner initDatabase(CustomerRepository customerRepository, StylistRepository
+//            stylistRepository, TimeSlotRepository timeSlotRepository, AppointmentRepository appointmentRepository) {
+//        return args -> {
+//            Customer customer1 = customerRepository.save(new Customer("Customer1", "Customer1@gmail.com"));
+//            Customer customer2 = customerRepository.save(new Customer("Customer2", "Customer2@gmail.com"));
+//            log.info("CUSTOMER " + customer1);
+//            log.info("CUSTOMER " + customer2);
+//
+//            Stylist stylist1 = stylistRepository.save(new Stylist("stylist1", "stylist1@gmail.com"));
+//            Stylist stylist2 = stylistRepository.save(new Stylist("stylist2", "stylist2@gmail.com"));
+//            log.info("STYLIST " + stylist1);
+//            log.info("STYLIST " + stylist2);
+//
+//            // Should return just one available since they cover the same time frame
+//            timeSlotRepository.save(new TimeSlot(stylist1,
+//                    LocalDate.now(),
+//                    LocalTime.of(6, 30),
+//                    LocalTime.of(7, 0)));
+//            timeSlotRepository.save(new TimeSlot(stylist2,
+//                    LocalDate.now(),
+//                    LocalTime.of(6, 30),
+//                    LocalTime.of(7, 0)));
+//
+//            TimeSlot slot1 = timeSlotRepository.save(
+//                    new TimeSlot(stylist1, LocalDate.now(), LocalTime.of(6, 0),
+//                            LocalTime.of(6, 30)));
+//            log.info("TIME SLOT " + slot1);
+//            log.info("TIME SLOT " + timeSlotRepository.save(new TimeSlot(stylist2, LocalDate.now(), LocalTime.of(6, 0),
+//                    LocalTime.of(6, 30))));
+//
+//            Appointment appointment1 = appointmentRepository.save(new Appointment(customer1, slot1));
+//            log.info("APPOINTMENT " + appointment1);
+//
+//            slot1.setAppointment(appointment1);
+//            log.info("UPDATE TIME SLOT " + timeSlotRepository.save(slot1));
+//
+//            List<TimeSlot> available = timeSlotRepository.findAllByDateBetweenAndAppointmentIsNull(LocalDate
+//                    .now().minusDays(1), LocalDate.now().plusDays(2));
+//            log.info("AVAILABLE " + available);
+//        };
+//    }
 
 }

--- a/src/main/java/com/otacilio/challange/stylistscheduler/controller/TimeSlotController.java
+++ b/src/main/java/com/otacilio/challange/stylistscheduler/controller/TimeSlotController.java
@@ -57,4 +57,12 @@ public class TimeSlotController {
                                                      LocalDate date) throws InvalidDateException {
         return service.findAvailable(date);
     }
+
+    @PostMapping("/initialise")
+    public Resources<Resource<TimeSlot>> initialize() {
+        List<Resource<TimeSlot>> result = service.initialize().stream()
+                .map(assembler::toResource)
+                .collect(Collectors.toList());
+        return new Resources<>(result, linkTo(methodOn(TimeSlotController.class).all()).withSelfRel());
+    }
 }

--- a/src/main/java/com/otacilio/challange/stylistscheduler/repository/TimeSlotRepository.java
+++ b/src/main/java/com/otacilio/challange/stylistscheduler/repository/TimeSlotRepository.java
@@ -16,4 +16,5 @@ public interface TimeSlotRepository extends CrudRepository<TimeSlot, Long>, JpaR
 
     List<TimeSlot> findAllByDateEqualsAndStartEqualsAndEndEquals(LocalDate date, LocalTime start, LocalTime end);
 
+    TimeSlot findFirstByOrderByDateDesc();
 }

--- a/src/main/java/com/otacilio/challange/stylistscheduler/service/TimeSlotService.java
+++ b/src/main/java/com/otacilio/challange/stylistscheduler/service/TimeSlotService.java
@@ -4,6 +4,7 @@ import com.otacilio.challange.stylistscheduler.exception.InvalidDateException;
 import com.otacilio.challange.stylistscheduler.exception.InvalidTimeSlotException;
 import com.otacilio.challange.stylistscheduler.exception.ResourceNotFoundException;
 import com.otacilio.challange.stylistscheduler.dto.AvailableTimeSlot;
+import com.otacilio.challange.stylistscheduler.model.Stylist;
 import com.otacilio.challange.stylistscheduler.model.TimeSlot;
 import com.otacilio.challange.stylistscheduler.repository.TimeSlotRepository;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -11,6 +12,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,9 +21,11 @@ import java.util.stream.Collectors;
 public class TimeSlotService {
 
     private TimeSlotRepository repository;
+    private StylistService stylistService;
 
-    public TimeSlotService(TimeSlotRepository repository) {
+    public TimeSlotService(TimeSlotRepository repository, StylistService stylistService) {
         this.repository = repository;
+        this.stylistService = stylistService;
     }
 
     public TimeSlot find(Long id) {
@@ -62,12 +67,54 @@ public class TimeSlotService {
 
     /**
      * Find all TimeSlots for the giver date, start and end
-     * @param date Date
+     *
+     * @param date  Date
      * @param start Starting HH:MM
-     * @param end Ending HH:MM
+     * @param end   Ending HH:MM
      * @return List of TimeSlots
      */
     public List<TimeSlot> findAll(LocalDate date, LocalTime start, LocalTime end) {
         return repository.findAllByDateEqualsAndStartEqualsAndEndEquals(date, start, end);
+    }
+
+
+    /**
+     * Generate all missing time slots for a period of 60 days starting from the current date. The starting time is
+     * hardcode to 09:00h and the end time to 18:00h (16slots/stylist/day). All slots have the same length of 30
+     * minutes. First checks for the oldest slot and assumes the day is full. Starts to initialise the slots
+     * starting from the day after
+     *
+     * @return List of TimeSlots
+     */
+    public List<TimeSlot> initialize() {
+
+        // Get oldest slot
+        TimeSlot oldest = repository.findFirstByOrderByDateDesc();
+        LocalDate startDate = LocalDate.now();
+
+        long initialIncrement = 0;
+        if (oldest != null && oldest.getDate().isAfter(startDate)) {
+            initialIncrement = startDate.until(oldest.getDate(), ChronoUnit.DAYS) + 1; // Day after the date found
+        }
+
+        List<TimeSlot> slots = new LinkedList<TimeSlot>();
+
+        for (Stylist stylist : stylistService.findAll()) {
+            for (long dayIncrement = initialIncrement; dayIncrement < 60; dayIncrement++) {
+
+                LocalTime currentTime = LocalTime.of(9,0);
+
+                for (int slotNumber = 0; slotNumber < 16; slotNumber++) {
+                    slots.add(new TimeSlot(
+                            stylist,
+                            startDate.plusDays(dayIncrement),
+                            currentTime,
+                            currentTime.plusMinutes(30)
+                    ));
+                    currentTime = currentTime.plusMinutes(30);
+                }
+            }
+        }
+        return repository.saveAll(slots);
     }
 }

--- a/src/test/java/com/otacilio/challange/stylistscheduler/service/TimeSlotServiceInitialisationTest.java
+++ b/src/test/java/com/otacilio/challange/stylistscheduler/service/TimeSlotServiceInitialisationTest.java
@@ -1,0 +1,84 @@
+package com.otacilio.challange.stylistscheduler.service;
+
+import com.otacilio.challange.stylistscheduler.dto.AvailableTimeSlot;
+import com.otacilio.challange.stylistscheduler.exception.InvalidDateException;
+import com.otacilio.challange.stylistscheduler.exception.InvalidTimeSlotException;
+import com.otacilio.challange.stylistscheduler.model.Appointment;
+import com.otacilio.challange.stylistscheduler.model.Customer;
+import com.otacilio.challange.stylistscheduler.model.Stylist;
+import com.otacilio.challange.stylistscheduler.model.TimeSlot;
+import com.otacilio.challange.stylistscheduler.repository.AppointmentRepository;
+import com.otacilio.challange.stylistscheduler.repository.CustomerRepository;
+import com.otacilio.challange.stylistscheduler.repository.StylistRepository;
+import com.otacilio.challange.stylistscheduler.repository.TimeSlotRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TimeSlotServiceInitialisationTest {
+
+    @Autowired
+    private TimeSlotService service;
+
+    @Autowired
+    private StylistRepository stylistRepository;
+
+    @Autowired
+    private TimeSlotRepository timeSlotRepository;
+
+    @Before
+    public void setUp() {
+        timeSlotRepository.deleteAll();
+        stylistRepository.deleteAll();
+    }
+
+    @Test
+    public void testInitialiseTimeSlotsNoStylist() {
+        List<TimeSlot> slots = service.initialize();
+        assertEquals(0, slots.size());
+    }
+
+    @Test
+    public void testInitialiseTimeSlotsOneStylist() {
+        stylistRepository.save(new Stylist("stylist1", "stylist1@gmail.com"));
+        List<TimeSlot> slots = service.initialize();
+        // 16 slots a day * 60 days
+        assertEquals(960, slots.size());
+    }
+
+    @Test
+    public void testInitialiseTimeSlotsOneStylistWithExistingTimeSlot() {
+        Stylist stylist = stylistRepository.save(new Stylist("stylist1", "stylist1@gmail.com"));
+
+        timeSlotRepository.save(new TimeSlot(stylist,
+                LocalDate.now().plusDays(2),
+                LocalTime.of(9, 0),
+                LocalTime.of(9, 30)));
+
+        List<TimeSlot> slots = service.initialize();
+        // There is a slot 2 days in the future so the slots to the first 3 days will not be generated.
+        // 16 slots a day * 57 days slot
+        assertEquals(912, slots.size());
+    }
+
+    @Test
+    public void testInitialiseTimeSlotsTwoStylists() {
+        stylistRepository.save(new Stylist("stylist1", "stylist1@gmail.com"));
+        stylistRepository.save(new Stylist("stylist2", "stylist2@gmail.com"));
+        List<TimeSlot> slots = service.initialize();
+        // 2 stylists * 16 slots a day * 60 days
+        assertEquals(1920, slots.size());
+    }
+}

--- a/src/test/java/com/otacilio/challange/stylistscheduler/service/TimeSlotServiceTest.java
+++ b/src/test/java/com/otacilio/challange/stylistscheduler/service/TimeSlotServiceTest.java
@@ -120,4 +120,5 @@ public class TimeSlotServiceTest {
     public void testGetAvailableTimeSlotsFutureDate() throws InvalidDateException {
         service.findAvailable(LocalDate.now().plusDays(31));
     }
+
 }


### PR DESCRIPTION
Generate all missing time slots for a period of 60 days starting from the current date. The starting time is hardcode to 09:00h and the end time to 18:00h (16slots/stylist/day). All slots have the same length of 30 minutes. It first checks for the oldest slot and assumes the day is full. Initialise the slots starting from the day after.